### PR TITLE
Set minimum iOS version to 9.0

### DIFF
--- a/HeckelDiff.podspec
+++ b/HeckelDiff.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/mcudich/HeckelDiff.git", :tag => s.version.to_s }
   s.social_media_url = "https://twitter.com/mcudich"
 
-  s.ios.deployment_target = "9.3"
+  s.ios.deployment_target = "9.0"
 
   s.source_files = "Source/**/*"
 end

--- a/HeckelDiff.xcodeproj/project.pbxproj
+++ b/HeckelDiff.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.matiascudich.HeckelDiff;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -370,6 +371,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.matiascudich.HeckelDiff;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
As discussed via twitter, the minimum iOS version of 9.3 is the default, and there is no technical requirement. this just sets the minimum iOS version to 9.0