### PR TITLE
Move reload to separate update block

### DIFF
--- a/Source/UICollectionView+Diff.swift
+++ b/Source/UICollectionView+Diff.swift
@@ -21,10 +21,15 @@ public extension UICollectionView {
     performBatchUpdates({
       self.deleteItems(at: update.deletions)
       self.insertItems(at: update.insertions)
-      self.reloadItems(at: update.updates)
       for move in update.moves {
         self.moveItem(at: move.from, to: move.to)
       }
+    }, completion: nil)
+
+    // reloadItems is done separately as the update indexes returne by diff() are in respect to the
+    // "after" state, but the collectionView.reloadItems() call wants the "before" indexPaths.
+    performBatchUpdates({
+        self.reloadItems(at: update.updates)
     }, completion: completion)
   }
 }

--- a/Source/UITableView+Diff.swift
+++ b/Source/UITableView+Diff.swift
@@ -23,11 +23,17 @@ public extension UITableView {
 
     deleteRows(at: update.deletions, with: animation)
     insertRows(at: update.insertions, with: animation)
-    reloadRows(at: update.updates, with: animation)
     for move in update.moves {
       moveRow(at: move.from, to: move.to)
     }
-
     endUpdates()
+
+    // reloadItems is done separately as the update indexes returne by diff() are in respect to the
+    // "after" state, but the collectionView.reloadItems() call wants the "before" indexPaths.
+    if update.updates.count > 0 {
+      beginUpdates()
+      reloadRows(at: update.updates, with: animation)
+      endUpdates()
+    }
   }
 }


### PR DESCRIPTION
https://github.com/mcudich/HeckelDiff/issues/9

reloadItems is done separately as the update indexes returne by diff() are in respect to the "after" state, but the collectionView.reloadItems() call wants the "before" indexPaths.