### PR TITLE
Adds parameter to UIKit method to skip the reload of updated cells.

### DIFF
--- a/Source/UICollectionView+Diff.swift
+++ b/Source/UICollectionView+Diff.swift
@@ -13,10 +13,11 @@ import UIKit
 public extension UICollectionView {
   /// Applies a batch update to the receiver, efficiently reporting changes between old and new.
   ///
-  /// - parameter old:       The previous state of the collection view.
-  /// - parameter new:       The current state of the collection view.
-  /// - parameter section:   The section where these changes took place.
-  func applyDiff<T: Collection>(_ old: T, _ new: T, inSection section: Int, completion: ((Bool) -> Void)?) where T.Iterator.Element: Hashable, T.IndexDistance == Int, T.Index == Int {
+  /// - parameter old:            The previous state of the collection view.
+  /// - parameter new:            The current state of the collection view.
+  /// - parameter section:        The section where these changes took place.
+  /// - parameter reloadUpdated:  Whether or not updated cells should be reloaded (default: true)
+  func applyDiff<T: Collection>(_ old: T, _ new: T, inSection section: Int, reloadUpdated: Bool = true, completion: ((Bool) -> Void)?) where T.Iterator.Element: Hashable, T.IndexDistance == Int, T.Index == Int {
     let update = ListUpdate(diff(old, new), section)
 
     performBatchUpdates({
@@ -25,13 +26,15 @@ public extension UICollectionView {
       for move in update.moves {
         self.moveItem(at: move.from, to: move.to)
       }
-    }, completion: nil)
+    }, completion: reloadUpdated ? nil : completion)
 
-    // reloadItems is done separately as the update indexes returne by diff() are in respect to the
-    // "after" state, but the collectionView.reloadItems() call wants the "before" indexPaths.
-    performBatchUpdates({
+    if reloadUpdated {
+      // reloadItems is done separately as the update indexes returne by diff() are in respect to the
+      // "after" state, but the collectionView.reloadItems() call wants the "before" indexPaths.
+      performBatchUpdates({
         self.reloadItems(at: update.updates)
-    }, completion: completion)
+      }, completion: completion)
+    }
   }
 }
 #endif

--- a/Source/UITableView+Diff.swift
+++ b/Source/UITableView+Diff.swift
@@ -13,11 +13,12 @@ import UIKit
 public extension UITableView {
   /// Applies a batch update to the receiver, efficiently reporting changes between old and new.
   ///
-  /// - parameter old:       The previous state of the table view.
-  /// - parameter new:       The current state of the table view.
-  /// - parameter section:   The section where these changes took place.
-  /// - parameter animation: The animation type.
-  func applyDiff<T: Collection>(_ old: T, _ new: T, inSection section: Int, withAnimation animation: UITableViewRowAnimation) where T.Iterator.Element: Hashable, T.IndexDistance == Int, T.Index == Int {
+  /// - parameter old:              The previous state of the table view.
+  /// - parameter new:              The current state of the table view.
+  /// - parameter section:          The section where these changes took place.
+  /// - parameter animation:        The animation type.
+  /// - parameter reloadUpdated:    Whether or not updated cells should be reloaded (default: true)
+  func applyDiff<T: Collection>(_ old: T, _ new: T, inSection section: Int, withAnimation animation: UITableViewRowAnimation, reloadUpdated: Bool = true) where T.Iterator.Element: Hashable, T.IndexDistance == Int, T.Index == Int {
     let update = ListUpdate(diff(old, new), section)
 
     beginUpdates()
@@ -31,7 +32,7 @@ public extension UITableView {
 
     // reloadItems is done separately as the update indexes returne by diff() are in respect to the
     // "after" state, but the collectionView.reloadItems() call wants the "before" indexPaths.
-    if update.updates.count > 0 {
+    if reloadUpdated && update.updates.count > 0 {
       beginUpdates()
       reloadRows(at: update.updates, with: animation)
       endUpdates()


### PR DESCRIPTION
Sometimes I need to update the visible cells directly (not through reloadCells), because otherwise in-cell animation won't work. Because of this this parameter might be useful. Because of the default value, this won't break any existing code.