### PR TITLE
Only set code files as source files in podspec

### DIFF
--- a/HeckelDiff.podspec
+++ b/HeckelDiff.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "8.0"
 
-  s.source_files = "Source/**/*"
+  s.source_files = "Source/**/*.{h,m,swift}"
 end


### PR DESCRIPTION
This should help with compatibility with the new build system. Right now you would get an error because Info.plist is produced multiple times. See a similar [issue with ActionKit](https://github.com/ActionKit/ActionKit/issues/31).