### PR TITLE
Check if order preserved 

### DIFF
--- a/Source/ListUpdate.swift
+++ b/Source/ListUpdate.swift
@@ -13,7 +13,7 @@ public struct ListUpdate {
   public var insertions = [IndexPath]()
   public var updates = [IndexPath]()
   public var moves = [(from: IndexPath, to: IndexPath)]()
-  public var isOrderChanged Bool {
+  public var isOrderChanged: Bool {
     return !(deletions.isEmpty && insertions.isEmpty && moves.isEmpty)
   }
 

--- a/Source/ListUpdate.swift
+++ b/Source/ListUpdate.swift
@@ -9,23 +9,26 @@
 import Foundation
 
 public struct ListUpdate {
-  public var deletions = [IndexPath]()
-  public var insertions = [IndexPath]()
-  public var updates = [IndexPath]()
-  public var moves = [(from: IndexPath, to: IndexPath)]()
-
-  public init(_ result: [Operation], _ section: Int) {
-    for step in result {
-      switch step {
-      case .delete(let index):
-        deletions.append(IndexPath(row: index, section: section))
-      case .insert(let index):
-        insertions.append(IndexPath(row: index, section: section))
-      case .update(let index):
-        updates.append(IndexPath(row: index, section: section))
-      case let .move(fromIndex, toIndex):
-        moves.append((from: IndexPath(row: fromIndex, section: section), to: IndexPath(row: toIndex, section: section)))
-      }
+    public var deletions = [IndexPath]()
+    public var insertions = [IndexPath]()
+    public var updates = [IndexPath]()
+    public var moves = [(from: IndexPath, to: IndexPath)]()
+    public var collectionUpdates: Bool {
+        return !(deletions.isEmpty && insertions.isEmpty && moves.isEmpty)
     }
-  }
+
+    public init(_ result: [Operation], _ section: Int) {
+        for step in result {
+            switch step {
+            case .delete(let index):
+                deletions.append(IndexPath(row: index, section: section))
+            case .insert(let index):
+                insertions.append(IndexPath(row: index, section: section))
+            case .update(let index):
+                updates.append(IndexPath(row: index, section: section))
+            case let .move(fromIndex, toIndex):
+                moves.append((from: IndexPath(row: fromIndex, section: section), to: IndexPath(row: toIndex, section: section)))
+            }
+        }
+    }
 }

--- a/Source/ListUpdate.swift
+++ b/Source/ListUpdate.swift
@@ -9,26 +9,26 @@
 import Foundation
 
 public struct ListUpdate {
-    public var deletions = [IndexPath]()
-    public var insertions = [IndexPath]()
-    public var updates = [IndexPath]()
-    public var moves = [(from: IndexPath, to: IndexPath)]()
-    public var collectionUpdates: Bool {
-        return !(deletions.isEmpty && insertions.isEmpty && moves.isEmpty)
-    }
+  public var deletions = [IndexPath]()
+  public var insertions = [IndexPath]()
+  public var updates = [IndexPath]()
+  public var moves = [(from: IndexPath, to: IndexPath)]()
+  public var isOrderChanged Bool {
+    return !(deletions.isEmpty && insertions.isEmpty && moves.isEmpty)
+  }
 
-    public init(_ result: [Operation], _ section: Int) {
-        for step in result {
-            switch step {
-            case .delete(let index):
-                deletions.append(IndexPath(row: index, section: section))
-            case .insert(let index):
-                insertions.append(IndexPath(row: index, section: section))
-            case .update(let index):
-                updates.append(IndexPath(row: index, section: section))
-            case let .move(fromIndex, toIndex):
-                moves.append((from: IndexPath(row: fromIndex, section: section), to: IndexPath(row: toIndex, section: section)))
-            }
-        }
+  public init(_ result: [Operation], _ section: Int) {
+    for step in result {
+      switch step {
+      case .delete(let index):
+        deletions.append(IndexPath(row: index, section: section))
+      case .insert(let index):
+        insertions.append(IndexPath(row: index, section: section))
+      case .update(let index):
+        updates.append(IndexPath(row: index, section: section))
+      case let .move(fromIndex, toIndex):
+        moves.append((from: IndexPath(row: fromIndex, section: section), to: IndexPath(row: toIndex, section: section)))
+      }
     }
+  }
 }

--- a/Source/UICollectionView+Diff.swift
+++ b/Source/UICollectionView+Diff.swift
@@ -20,7 +20,7 @@ public extension UICollectionView {
   func applyDiff<T: Collection>(_ old: T, _ new: T, inSection section: Int, reloadUpdated: Bool = true, completion: ((Bool) -> Void)?) where T.Iterator.Element: Hashable, T.Index == Int {
     let update = ListUpdate(diff(old, new), section)
 
-    if update.collectionUpdates {
+    if update.isOrderChanged {
         performBatchUpdates({
             self.deleteItems(at: update.deletions)
             self.insertItems(at: update.insertions)

--- a/Source/UICollectionView+Diff.swift
+++ b/Source/UICollectionView+Diff.swift
@@ -20,13 +20,15 @@ public extension UICollectionView {
   func applyDiff<T: Collection>(_ old: T, _ new: T, inSection section: Int, reloadUpdated: Bool = true, completion: ((Bool) -> Void)?) where T.Iterator.Element: Hashable, T.Index == Int {
     let update = ListUpdate(diff(old, new), section)
 
-    performBatchUpdates({
-      self.deleteItems(at: update.deletions)
-      self.insertItems(at: update.insertions)
-      for move in update.moves {
-        self.moveItem(at: move.from, to: move.to)
-      }
-    }, completion: reloadUpdated ? nil : completion)
+    if update.collectionUpdates {
+        performBatchUpdates({
+            self.deleteItems(at: update.deletions)
+            self.insertItems(at: update.insertions)
+            for move in update.moves {
+                self.moveItem(at: move.from, to: move.to)
+            }
+        }, completion: reloadUpdated ? nil : completion)
+    }
 
     if reloadUpdated {
       // reloadItems is done separately as the update indexes returne by diff() are in respect to the

--- a/Source/UITableView+Diff.swift
+++ b/Source/UITableView+Diff.swift
@@ -21,14 +21,16 @@ public extension UITableView {
   func applyDiff<T: Collection>(_ old: T, _ new: T, inSection section: Int, withAnimation animation: UITableViewRowAnimation, reloadUpdated: Bool = true) where T.Iterator.Element: Hashable, T.Index == Int {
     let update = ListUpdate(diff(old, new), section)
 
-    beginUpdates()
+    if update.collectionUpdates {
+        beginUpdates()
 
-    deleteRows(at: update.deletions, with: animation)
-    insertRows(at: update.insertions, with: animation)
-    for move in update.moves {
-      moveRow(at: move.from, to: move.to)
+        deleteRows(at: update.deletions, with: animation)
+        insertRows(at: update.insertions, with: animation)
+        for move in update.moves {
+            moveRow(at: move.from, to: move.to)
+        }
+        endUpdates()
     }
-    endUpdates()
 
     // reloadItems is done separately as the update indexes returne by diff() are in respect to the
     // "after" state, but the collectionView.reloadItems() call wants the "before" indexPaths.

--- a/Source/UITableView+Diff.swift
+++ b/Source/UITableView+Diff.swift
@@ -21,7 +21,7 @@ public extension UITableView {
   func applyDiff<T: Collection>(_ old: T, _ new: T, inSection section: Int, withAnimation animation: UITableViewRowAnimation, reloadUpdated: Bool = true) where T.Iterator.Element: Hashable, T.Index == Int {
     let update = ListUpdate(diff(old, new), section)
 
-    if update.collectionUpdates {
+    if update.isOrderChanged {
         beginUpdates()
 
         deleteRows(at: update.deletions, with: animation)


### PR DESCRIPTION
It lets avoid an interface bug in case when after update there isn't changes. I caught a case when there was only one cell in a table view and after pull to refresh I got extra space between activity view and first cell.