### PR TITLE
Explicitly set deployment targets for all platforms, make sure tests are running on macOS 

### DIFF
--- a/HeckelDiff.xcodeproj/project.pbxproj
+++ b/HeckelDiff.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -294,8 +295,10 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -344,14 +347,17 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -368,7 +374,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.matiascudich.HeckelDiff;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -392,7 +397,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.matiascudich.HeckelDiff;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -411,6 +415,7 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.matiascudich.HeckelDiffTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -428,6 +433,7 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.matiascudich.HeckelDiffTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Source/ListUpdate.swift
+++ b/Source/ListUpdate.swift
@@ -7,6 +7,11 @@
 //
 
 import Foundation
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 public struct ListUpdate {
   public var deletions = [IndexPath]()
@@ -18,13 +23,13 @@ public struct ListUpdate {
     for step in result {
       switch step {
       case .delete(let index):
-        deletions.append(IndexPath(row: index, section: section))
+        deletions.append(IndexPath(item: index, section: section))
       case .insert(let index):
-        insertions.append(IndexPath(row: index, section: section))
+        insertions.append(IndexPath(item: index, section: section))
       case .update(let index):
-        updates.append(IndexPath(row: index, section: section))
+        updates.append(IndexPath(item: index, section: section))
       case let .move(fromIndex, toIndex):
-        moves.append((from: IndexPath(row: fromIndex, section: section), to: IndexPath(row: toIndex, section: section)))
+        moves.append((from: IndexPath(item: fromIndex, section: section), to: IndexPath(item: toIndex, section: section)))
       }
     }
   }


### PR DESCRIPTION
Hey!

This PR is intended to improve multi-platform support of this project and does basically 3 things:

1. Explicitly set tvOS, macOS and watchOS targets
2. Provide search paths for test target for macOS
3. Replace IndexPath(row:section:) constructor with IndexPath(item:section:)

1 is needed because when you build using Carthage, when deployment targets are not selected, Xcode compiles binary for latest deployment target(for example when building for tvOS in Xcode 10 - tvOS 12), which does not allow to use this binary for lower deployment targets like tvOS 11 or tvOS 10.
2 is needed because on macOS, framework search paths is slightly different than iOS and tvOS. This can be verified by running tests on macOS target before and after this change. Before - tests would fail with frameworks missing runtime error in console.
3 change is made because IndexPath(row:section:) constructor is only available on iOS, and is not available in macOS. IndexPath(item:section), on other hand, is available on all platforms, and therefore is better suited for cross-platform.