### PR TITLE
Fix Xcode 12 warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,37 +1,10 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 //
-//  Package.swift
-//  HeckelDiff
-//
-//  Created by Denys Telezhkin on 09.07.2019.
-//  Copyright © 2019 Denys Telezhkin. All rights reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
 
 import PackageDescription
 
 let package = Package(
     name: "HeckelDiff",
-    platforms: [
-        .iOS(.v8),
-        .tvOS(.v9)
-    ],
     products: [
         .library(name: "HeckelDiff", targets: ["HeckelDiff"])
     ],

--- a/Source/Diff.swift
+++ b/Source/Diff.swift
@@ -26,7 +26,7 @@ public enum Operation: Equatable {
     case let (.insert(l), .insert(r)),
          let (.delete(l), .delete(r)),
          let (.update(l), .update(r)): return l == r
-    case let (.move(l), .move(r)): return l == r
+    case let (.move(l1,l2), .move(r1,r2)): return l1 == r1 && l2 == r2
     default: return false
     }
   }


### PR DESCRIPTION
SPM in Xcode 12 bumps minimum iOS deployment target to iOS 9, which produces warnings when trying to use Dwifft.

This PR fixes that by deleting minimum supported platforms from Package.swift. This way minimum deployment targets are determined by build tools themselves.

Also fixed one Swift warning for Swift 5.3, and removed copyright header, which does not seem to be needed here :)